### PR TITLE
Share an http.Client between requests

### DIFF
--- a/request.go
+++ b/request.go
@@ -7,20 +7,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"time"
 )
 
 // change timeout to time.Duration
-func request(method, url string, body []byte, timeout time.Duration) ([]byte, error) {
-
-	if timeout == 0 {
-		timeout = time.Second * 5
-	}
-
-	client := &http.Client{Timeout: timeout}
-
-	// use httpClient Timeout attribute - otherwise there will be a leak
-
+func request(client *http.Client, method, url string, body []byte) ([]byte, error) {
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := client.Do(req)


### PR DESCRIPTION
Allows to use http KeepAlive or pipelining and also configure the
transport. client.Timeout is copies to the http.Client on each request
if it has changed. It's not ideal but it keeps backward-compatibility.

Closes #1