### PR TITLE
HTTP Client publically available to configure. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ If you wish to set a time-limit for each HTTP request, create a `http.Client` in
 
 httpClient := &http.Client{Timeout: time.Second * 3}
 
-pusherClient.Client = httpClient
+pusherClient.HttpClient = httpClient
 ```
 
 If you do not specifically set a HTTP client, a default one is created with a timeout of 5 seconds.
@@ -119,7 +119,7 @@ By default, this is `"api.pusherapp.com"`.
 
 ### Google App Engine
 
-As of version 0.3.0, this library is compatible with Google App Engine's urlfetch library. Simply pass in the HTTP client returned by `urlfetch.Client` to your Pusher initialization struct.
+As of version 1.0.0, this library is compatible with Google App Engine's urlfetch library. Simply pass in the HTTP client returned by `urlfetch.Client` to your Pusher initialization struct.
 
 ```go
 package helloworldapp
@@ -145,7 +145,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		AppId:  "app_id",
 		Key:    "key",
 		Secret: "secret",
-		Client: urlfetchClient,
+		HttpClient: urlfetchClient,
 	}
 
 	client.Trigger("test_channel", "my_event", map[string]string{"message": "hello world"})

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ In order to use this library, you need to have a free account on <http://pusher.
 - [Getting Started](#getting-started)
 - [Configuration](#configuration)
   - [Additional options](#additional-options)
+  - [Google App Engine](#google-app-engine)
 - [Usage](#usage)
   - [Triggering events](#triggering-events)
   - [Excluding event recipients](#excluding-event-recipients)
@@ -95,15 +96,16 @@ This is `false` by default.
 
 #### Request Timeouts
 
-If you wish to set a time-limit for each HTTP request, set the `Timeout` property to an instance of `time.Duration`, for example:
+If you wish to set a time-limit for each HTTP request, create a `http.Client` instance with your specified `Timeout` field and set it as the Pusher instance's `Client`:
 
 ```go
-import "time"
 
-client.Timeout = time.Second * 3 // set the timeout to 3 seconds
+httpClient := &http.Client{Timeout: time.Second * 3}
+
+pusherClient.Client = httpClient
 ```
 
-By default, timeouts will be 5 seconds.
+If you do not specifically set a HTTP client, a default one is created with a timeout of 5 seconds.
 
 #### Changing Host
 
@@ -114,6 +116,43 @@ client.Host = "foo.bar.com"
 ```
 
 By default, this is `"api.pusherapp.com"`.
+
+### Google App Engine
+
+As of version 0.3.0, this library is compatible with Google App Engine's urlfetch library. Simply pass in the HTTP client returned by `urlfetch.Client` to your Pusher initialization struct.
+
+```go
+package helloworldapp
+
+import (
+	"appengine"
+	"appengine/urlfetch"
+	"fmt"
+	"github.com/pusher/pusher-http-go"
+	"net/http"
+)
+
+func init() {
+	http.HandleFunc("/", handler)
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+
+	c := appengine.NewContext(r)
+	urlfetchClient := urlfetch.Client(c)
+
+	client := pusher.Client{
+		AppId:  "app_id",
+		Key:    "key",
+		Secret: "secret",
+		Client: urlfetchClient,
+	}
+
+	client.Trigger("test_channel", "my_event", map[string]string{"message": "hello world"})
+
+	fmt.Fprint(w, "Hello, world!")
+}
+```
 
 ## Usage
 

--- a/client.go
+++ b/client.go
@@ -40,12 +40,12 @@ Changing the `pusher.Client`'s `Host` property will make sure requests are sent 
 
 */
 type Client struct {
-	AppId  string
-	Key    string
-	Secret string
-	Host   string // host or host:port pair
-	Secure bool   // true for HTTPS
-	Client *http.Client
+	AppId      string
+	Key        string
+	Secret     string
+	Host       string // host or host:port pair
+	Secure     bool   // true for HTTPS
+	HttpClient *http.Client
 }
 
 /*
@@ -103,16 +103,16 @@ func ClientFromEnv(key string) (*Client, error) {
 Returns the underlying HTTP client.
 Useful to set custom properties to it.
 */
-func (c *Client) httpClient() *http.Client {
-	if c.Client == nil {
-		c.Client = &http.Client{Timeout: time.Second * 5}
+func (c *Client) requestClient() *http.Client {
+	if c.HttpClient == nil {
+		c.HttpClient = &http.Client{Timeout: time.Second * 5}
 	}
 
-	return c.Client
+	return c.HttpClient
 }
 
 func (c *Client) request(method, url string, body []byte) ([]byte, error) {
-	return request(c.httpClient(), method, url, body)
+	return request(c.requestClient(), method, url, body)
 }
 
 /*

--- a/client.go
+++ b/client.go
@@ -40,13 +40,12 @@ Changing the `pusher.Client`'s `Host` property will make sure requests are sent 
 
 */
 type Client struct {
-	AppId   string
-	Key     string
-	Secret  string
-	Host    string        // host or host:port pair
-	Secure  bool          // true for HTTPS
-	Timeout time.Duration // Request timeout for HTTP requests
-	client  *http.Client
+	AppId  string
+	Key    string
+	Secret string
+	Host   string // host or host:port pair
+	Secure bool   // true for HTTPS
+	Client *http.Client
 }
 
 /*
@@ -104,21 +103,16 @@ func ClientFromEnv(key string) (*Client, error) {
 Returns the underlying HTTP client.
 Useful to set custom properties to it.
 */
-func (c *Client) HttpClient() *http.Client {
-	if c.client == nil {
-		c.client = new(http.Client)
+func (c *Client) httpClient() *http.Client {
+	if c.Client == nil {
+		c.Client = &http.Client{Timeout: time.Second * 5}
 	}
-	if c.Timeout == 0 {
-		c.Timeout = time.Second * 5
-	}
-	if c.client.Timeout != c.Timeout {
-		c.client.Timeout = c.Timeout
-	}
-	return c.client
+
+	return c.Client
 }
 
 func (c *Client) request(method, url string, body []byte) ([]byte, error) {
-	return request(c.HttpClient(), method, url, body)
+	return request(c.httpClient(), method, url, body)
 }
 
 /*

--- a/client_test.go
+++ b/client_test.go
@@ -85,7 +85,7 @@ func TestRequestTimeouts(t *testing.T) {
 	defer server.Close()
 
 	u, _ := url.Parse(server.URL)
-	client := Client{AppId: "id", Key: "key", Secret: "secret", Host: u.Host, Client: &http.Client{Timeout: time.Millisecond * 100}}
+	client := Client{AppId: "id", Key: "key", Secret: "secret", Host: u.Host, HttpClient: &http.Client{Timeout: time.Millisecond * 100}}
 
 	_, err := client.Trigger("test_channel", "test", "yolo")
 

--- a/client_test.go
+++ b/client_test.go
@@ -85,8 +85,7 @@ func TestRequestTimeouts(t *testing.T) {
 	defer server.Close()
 
 	u, _ := url.Parse(server.URL)
-	client := Client{AppId: "id", Key: "key", Secret: "secret", Host: u.Host}
-	client.Timeout = time.Millisecond * 100
+	client := Client{AppId: "id", Key: "key", Secret: "secret", Host: u.Host, Client: &http.Client{Timeout: time.Millisecond * 100}}
 
 	_, err := client.Trigger("test_channel", "test", "yolo")
 


### PR DESCRIPTION
If HTTP client not explicitly given, library creates one with a default timeout of 5. Compatible with GAE. 