### PR TITLE
New initialization improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: go
 go: 
   - 1.3
+  - 1.4
+  - 1.5
   - tip
 install: 
   - go get github.com/stretchr/testify/assert

--- a/channel_authentication_test.go
+++ b/channel_authentication_test.go
@@ -7,8 +7,8 @@ import (
 
 func setUpAuthClient() Client {
 	return Client{
-		Key:    "278d425bdf160c739803",
-		Secret: "7ad3773142a6692b25b8",
+		key:    "278d425bdf160c739803",
+		secret: "7ad3773142a6692b25b8",
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -169,7 +169,6 @@ func TestRequestTimeouts(t *testing.T) {
 	_, err := client.Trigger("test_channel", "test", "yolo")
 
 	assert.Error(t, err)
-
 }
 
 func TestChannelLengthValidation(t *testing.T) {
@@ -191,7 +190,7 @@ func TestChannelFormatValidation(t *testing.T) {
 		channel2 += "a"
 	}
 
-	client := Client{AppId: "id", Key: "key", Secret: "secret"}
+	client := Client{appId: "id", key: "key", secret: "secret"}
 	res1, err1 := client.Trigger(channel1, "yolo", "w00t")
 
 	res2, err2 := client.Trigger(channel2, "yolo", "not 19 forever")
@@ -205,7 +204,7 @@ func TestChannelFormatValidation(t *testing.T) {
 }
 
 func TestDataSizeValidation(t *testing.T) {
-	client := Client{AppId: "id", Key: "key", Secret: "secret"}
+	client := Client{appId: "id", key: "key", secret: "secret"}
 
 	var data string
 
@@ -252,4 +251,24 @@ func TestInitialisationFromENV(t *testing.T) {
 	client, _ := ClientFromEnv("PUSHER_URL")
 	expectedClient, _ := NewWithConfig("104060", "feaf18a411d3cb9216ee", "fec81108d90e1898e17a", &Config{Host: "api.pusherapp.com"})
 	assert.Equal(t, expectedClient, client)
+}
+
+func TestDefaultInitialisationWithNew(t *testing.T) {
+	client, _ := New("id", "key", "secret")
+	expectedClient := &Client{"id", "key", "secret", &Config{}}
+	assert.Equal(t, client, expectedClient)
+}
+
+func TestInitialisationWithParams(t *testing.T) {
+	config := &Config{
+		Secure:        true,
+		HttpTransport: &http.Transport{DisableKeepAlives: true},
+		HttpClient:    &http.Client{},
+	}
+	client, _ := NewWithConfig("id", "key", "secret", config)
+	expectedClient := &Client{"id", "key", "secret", config}
+	assert.Equal(t, client, expectedClient)
+	assert.Equal(t, client.Secure, true)
+	assert.Equal(t, client.HttpTransport, &http.Transport{DisableKeepAlives: true})
+	assert.Equal(t, client.HttpClient, &http.Client{})
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func setUpClient() Client {
-	return Client{AppId: "id", Key: "key", Secret: "secret"}
+	return Client{appId: "id", key: "key", secret: "secret"}
 }
 
 func TestClientWebhookValidation(t *testing.T) {


### PR DESCRIPTION
Largely based on what @jpatel531 did in the `new-initialization` branch. Incorporated feedback from @zimbatm and also added ability to pass in a `http.Transport{}` struct to pass to the `http.Client` instance. Also allows setting the `Timeout` property directly on the `Client` struct.
