### PR TITLE
strings should not be json parsed

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -18,7 +18,7 @@ func TestTriggerSuccessCase(t *testing.T) {
 		fmt.Fprintf(res, "{}")
 		assert.Equal(t, "POST", req.Method)
 
-		expected_body := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"\\\"yolo\\\"\"}"
+		expected_body := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"yolo\"}"
 		actual_body, err := ioutil.ReadAll(req.Body)
 		assert.Equal(t, expected_body, string(actual_body))
 		assert.Equal(t, "application/json", req.Header["Content-Type"][0])
@@ -111,7 +111,7 @@ func TestTriggerWithSocketId(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(200)
 
-		expected_body := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"\\\"yolo\\\"\",\"socket_id\":\"1234.12\"}"
+		expected_body := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"yolo\",\"socket_id\":\"1234.12\"}"
 		actual_body, err := ioutil.ReadAll(req.Body)
 		assert.Equal(t, expected_body, string(actual_body))
 		assert.NoError(t, err)

--- a/event.go
+++ b/event.go
@@ -17,18 +17,29 @@ type BufferedEvents struct {
 }
 
 func createTriggerPayload(channels []string, event string, data interface{}, socketId *string) ([]byte, error) {
-	data2, err := json.Marshal(data)
-	if err != nil {
-		return nil, err
+	var dataBytes []byte
+	var err error
+
+	switch d := data.(type) {
+	case []byte:
+		dataBytes = d
+	case string:
+		dataBytes = []byte(d)
+	default:
+		dataBytes, err = json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
 	}
-	if len(data2) > 10240 {
+
+	if len(dataBytes) > 10240 {
 		return nil, errors.New("Data must be smaller than 10kb")
 	}
 
 	return json.Marshal(&eventPayload{
 		Name:     event,
 		Channels: channels,
-		Data:     string(data2),
+		Data:     string(dataBytes),
 		SocketId: socketId,
 	})
 }


### PR DESCRIPTION
In some cases the payload has already been JSON parsed so it would be better to allow raw strings