### PR TITLE
some golint fixes

### DIFF
--- a/channel_authentication_test.go
+++ b/channel_authentication_test.go
@@ -14,26 +14,26 @@ func setUpAuthClient() Client {
 
 func TestPrivateChannelAuthentication(t *testing.T) {
 	client := setUpAuthClient()
-	post_params := []byte("channel_name=private-foobar&socket_id=1234.1234")
+	postParams := []byte("channel_name=private-foobar&socket_id=1234.1234")
 	expected := "{\"auth\":\"278d425bdf160c739803:58df8b0c36d6982b82c3ecf6b4662e34fe8c25bba48f5369f135bf843651c3a4\"}"
-	result, err := client.AuthenticatePrivateChannel(post_params)
+	result, err := client.AuthenticatePrivateChannel(postParams)
 	assert.Equal(t, expected, string(result))
 	assert.NoError(t, err)
 }
 
 func TestPrivateChannelAuthenticationWrongParams(t *testing.T) {
 	client := setUpAuthClient()
-	post_params := []byte("hello=hi&two=3")
-	_, err := client.AuthenticatePrivateChannel(post_params)
+	postParams := []byte("hello=hi&two=3")
+	_, err := client.AuthenticatePrivateChannel(postParams)
 	assert.Error(t, err)
 }
 
 func TestPresenceChannelAuthentication(t *testing.T) {
 	client := setUpAuthClient()
-	post_params := []byte("channel_name=presence-foobar&socket_id=1234.1234")
-	presence_data := MemberData{UserId: "10", UserInfo: map[string]string{"name": "Mr. Pusher"}}
+	postParams := []byte("channel_name=presence-foobar&socket_id=1234.1234")
+	presenceData := MemberData{UserId: "10", UserInfo: map[string]string{"name": "Mr. Pusher"}}
 	expected := "{\"auth\":\"278d425bdf160c739803:48dac51d2d7569e1e9c0f48c227d4b26f238fa68e5c0bb04222c966909c4f7c4\",\"channel_data\":\"{\\\"user_id\\\":\\\"10\\\",\\\"user_info\\\":{\\\"name\\\":\\\"Mr. Pusher\\\"}}\"}"
-	result, err := client.AuthenticatePresenceChannel(post_params, presence_data)
+	result, err := client.AuthenticatePresenceChannel(postParams, presenceData)
 	assert.Equal(t, expected, string(result))
 	assert.NoError(t, err)
 }

--- a/client.go
+++ b/client.go
@@ -162,7 +162,7 @@ func (c *Client) TriggerMultiExclusive(channels []string, event string, data int
 	return c.trigger(channels, event, data, &socketID)
 }
 
-func (c *Client) trigger(channels []string, event string, data interface{}, socketId *string) (*BufferedEvents, error) {
+func (c *Client) trigger(channels []string, event string, data interface{}, socketID *string) (*BufferedEvents, error) {
 	if len(channels) > 10 {
 		return nil, errors.New("You cannot trigger on more than 10 channels at once")
 	}
@@ -171,17 +171,17 @@ func (c *Client) trigger(channels []string, event string, data interface{}, sock
 		return nil, errors.New("At least one of your channels' names are invalid")
 	}
 
-	if err := validateSocketId(socketId); err != nil {
+	if err := validateSocketID(socketID); err != nil {
 		return nil, err
 	}
 
-	payload, err := createTriggerPayload(channels, event, data, socketId)
+	payload, err := createTriggerPayload(channels, event, data, socketID)
 	if err != nil {
 		return nil, err
 	}
 
 	path := fmt.Sprintf("/apps/%s/events", c.AppId)
-	u := createRequestUrl("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, payload, nil, c.Cluster)
+	u := createRequestURL("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, payload, nil, c.Cluster)
 	response, err := c.request("POST", u, payload)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ specify an `"info"` key with value `"user_count"`. Pass in `nil` if you do not w
 */
 func (c *Client) Channels(additionalQueries map[string]string) (*ChannelsList, error) {
 	path := fmt.Sprintf("/apps/%s/channels", c.AppId)
-	u := createRequestUrl("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
+	u := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
 	response, err := c.request("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -236,7 +236,7 @@ if you wish to enable this. Pass in `nil` if you do not wish to specify any quer
 */
 func (c *Client) Channel(name string, additionalQueries map[string]string) (*Channel, error) {
 	path := fmt.Sprintf("/apps/%s/channels/%s", c.AppId, name)
-	u := createRequestUrl("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
+	u := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
 	response, err := c.request("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -254,7 +254,7 @@ Get a list of users in a presence-channel by passing to this method the channel 
 */
 func (c *Client) GetChannelUsers(name string) (*Users, error) {
 	path := fmt.Sprintf("/apps/%s/channels/%s/users", c.AppId, name)
-	u := createRequestUrl("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, nil, c.Cluster)
+	u := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, nil, c.Cluster)
 	response, err := c.request("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -335,17 +335,17 @@ func (c *Client) AuthenticatePresenceChannel(params []byte, member MemberData) (
 }
 
 func (c *Client) authenticateChannel(params []byte, member *MemberData) (response []byte, err error) {
-	channelName, socketId, err := parseAuthRequestParams(params)
+	channelName, socketID, err := parseAuthRequestParams(params)
 
 	if err != nil {
 		return
 	}
 
-	if err = validateSocketId(&socketId); err != nil {
+	if err = validateSocketID(&socketID); err != nil {
 		return
 	}
 
-	stringToSign := strings.Join([]string{socketId, channelName}, ":")
+	stringToSign := strings.Join([]string{socketID, channelName}, ":")
 
 	var jsonUserData string
 

--- a/client_test.go
+++ b/client_test.go
@@ -18,9 +18,9 @@ func TestTriggerSuccessCase(t *testing.T) {
 		fmt.Fprintf(res, "{}")
 		assert.Equal(t, "POST", req.Method)
 
-		expected_body := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"yolo\"}"
-		actual_body, err := ioutil.ReadAll(req.Body)
-		assert.Equal(t, expected_body, string(actual_body))
+		expectedBody := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"yolo\"}"
+		actualBody, err := ioutil.ReadAll(req.Body)
+		assert.Equal(t, expectedBody, string(actualBody))
 		assert.Equal(t, "application/json", req.Header["Content-Type"][0])
 		assert.NoError(t, err)
 
@@ -111,9 +111,9 @@ func TestTriggerWithSocketId(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(200)
 
-		expected_body := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"yolo\",\"socket_id\":\"1234.12\"}"
-		actual_body, err := ioutil.ReadAll(req.Body)
-		assert.Equal(t, expected_body, string(actual_body))
+		expectedBody := "{\"name\":\"test\",\"channels\":[\"test_channel\"],\"data\":\"yolo\",\"socket_id\":\"1234.12\"}"
+		actualBody, err := ioutil.ReadAll(req.Body)
+		assert.Equal(t, expectedBody, string(actualBody))
 		assert.NoError(t, err)
 
 	}))

--- a/event.go
+++ b/event.go
@@ -16,7 +16,7 @@ type BufferedEvents struct {
 	EventIds map[string]string `json:"event_ids,omitempty"`
 }
 
-func createTriggerPayload(channels []string, event string, data interface{}, socketId *string) ([]byte, error) {
+func createTriggerPayload(channels []string, event string, data interface{}, socketID *string) ([]byte, error) {
 	var dataBytes []byte
 	var err error
 
@@ -40,6 +40,6 @@ func createTriggerPayload(channels []string, event string, data interface{}, soc
 		Name:     event,
 		Channels: channels,
 		Data:     string(dataBytes),
-		SocketId: socketId,
+		SocketId: socketID,
 	})
 }

--- a/request.go
+++ b/request.go
@@ -31,9 +31,8 @@ func processResponse(response *http.Response) ([]byte, error) {
 
 	if response.StatusCode == 200 {
 		return responseBody, nil
-	} else {
-		message := fmt.Sprintf("Status Code: %s - %s", strconv.Itoa(response.StatusCode), string(responseBody))
-		err := errors.New(message)
-		return nil, err
 	}
+	message := fmt.Sprintf("Status Code: %s - %s", strconv.Itoa(response.StatusCode), string(responseBody))
+	err = errors.New(message)
+	return nil, err
 }

--- a/request_url.go
+++ b/request_url.go
@@ -28,15 +28,15 @@ func unsignedParams(key, timestamp string, body []byte, additionalQueries map[st
 
 }
 
-func unescapeUrl(_url url.Values) string {
+func unescapeURL(_url url.Values) string {
 	unesc, _ := url.QueryUnescape(_url.Encode())
 	return unesc
 }
 
-func createRequestUrl(method, host, path, key, secret, timestamp string, secure bool, body []byte, additionalQueries map[string]string, cluster string) string {
+func createRequestURL(method, host, path, key, secret, timestamp string, secure bool, body []byte, additionalQueries map[string]string, cluster string) string {
 	params := unsignedParams(key, timestamp, body, additionalQueries)
 
-	stringToSign := strings.Join([]string{method, path, unescapeUrl(params)}, "\n")
+	stringToSign := strings.Join([]string{method, path, unescapeURL(params)}, "\n")
 
 	authSignature := hmacSignature(stringToSign, secret)
 
@@ -61,7 +61,7 @@ func createRequestUrl(method, host, path, key, secret, timestamp string, secure 
 	if err != nil {
 		panic("logic error: " + err.Error())
 	}
-	endpoint.RawQuery = unescapeUrl(params)
+	endpoint.RawQuery = unescapeURL(params)
 
 	return endpoint.String()
 }

--- a/request_url_test.go
+++ b/request_url_test.go
@@ -8,61 +8,61 @@ import (
 func TestTriggerRequestUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestUrl("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
+	result := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestBuildClusterTriggerUrl(t *testing.T) {
 	expected := "http://api-eu.pusher.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestUrl("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "eu")
+	result := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "eu")
 	assert.Equal(t, expected, result)
 }
 
 func TestBuildCustomHostTriggerUrl(t *testing.T) {
 	expected := "http://my.server.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestUrl("POST", "my.server.com", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
+	result := createRequestURL("POST", "my.server.com", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestTriggerSecureRequestUrl(t *testing.T) {
 	expected := "https://api.pusherapp.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestUrl("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", true, payload, nil, "")
+	result := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", true, payload, nil, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetAllChannelsUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels?auth_key=d41a439c438a100756f5&auth_signature=4d8a02edcc8a758b0162cd6da690a9a45fb8ae326a276dca1e06a0bc42796c11&auth_timestamp=1427034994&auth_version=1.0&filter_by_prefix=presence-&info=user_count"
-	additional_queries := map[string]string{"filter_by_prefix": "presence-", "info": "user_count"}
-	result := createRequestUrl("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427034994", false, nil, additional_queries, "")
+	additionalQueries := map[string]string{"filter_by_prefix": "presence-", "info": "user_count"}
+	result := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427034994", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetAllChannelsWithOneAdditionalParamUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels?auth_key=d41a439c438a100756f5&auth_signature=b540383af4582af5fbb5df7be5472d54bd0838c9c2021c7743062568839e6f97&auth_timestamp=1427036577&auth_version=1.0&filter_by_prefix=presence-"
-	additional_queries := map[string]string{"filter_by_prefix": "presence-"}
-	result := createRequestUrl("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036577", false, nil, additional_queries, "")
+	additionalQueries := map[string]string{"filter_by_prefix": "presence-"}
+	result := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036577", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetAllChannelsWithNoParamsUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels?auth_key=d41a439c438a100756f5&auth_signature=df89248f87f6e6d028925e0b04d60f316527a865992ace6936afa91281d8bef0&auth_timestamp=1427036787&auth_version=1.0"
-	additional_queries := map[string]string{}
-	result := createRequestUrl("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036787", false, nil, additional_queries, "")
+	additionalQueries := map[string]string{}
+	result := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036787", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetChannelUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-ROpCFmgFhXY?auth_key=d41a439c438a100756f5&auth_signature=f93ceb31f396aef336226efe512aaf339bd5e39c7c2c04b81cc8681dc16ee785&auth_timestamp=1427053326&auth_version=1.0&info=user_count,subscription_count"
-	additional_queries := map[string]string{"info": "user_count,subscription_count"}
-	result := createRequestUrl("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-ROpCFmgFhXY", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053326", false, nil, additional_queries, "")
+	additionalQueries := map[string]string{"info": "user_count,subscription_count"}
+	result := createRequestURL("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-ROpCFmgFhXY", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053326", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetUsersUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-nYJLy67qh52/users?auth_key=d41a439c438a100756f5&auth_signature=207feaf4e8efeb24e5f148011704251bf90e2059a5f97a3eb52d06178b11feca&auth_timestamp=1427053709&auth_version=1.0"
-	result := createRequestUrl("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-nYJLy67qh52/users", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053709", false, nil, nil, "")
+	result := createRequestURL("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-nYJLy67qh52/users", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053709", false, nil, nil, "")
 	assert.Equal(t, expected, result)
 }

--- a/util.go
+++ b/util.go
@@ -9,7 +9,7 @@ import (
 )
 
 var channelValidationRegex = regexp.MustCompile("^[-a-zA-Z0-9_=@,.;]+$")
-var socketIdValidationRegex = regexp.MustCompile(`\A\d+\.\d+\z`)
+var socketIDValidationRegex = regexp.MustCompile(`\A\d+\.\d+\z`)
 
 func authTimestamp() string {
 	return strconv.FormatInt(time.Now().Unix(), 10)
@@ -43,10 +43,9 @@ func channelsAreValid(channels []string) bool {
 	return true
 }
 
-func validateSocketId(socketId *string) (err error) {
-	if (socketId == nil) || socketIdValidationRegex.MatchString(*socketId) {
+func validateSocketID(socketID *string) (err error) {
+	if (socketID == nil) || socketIDValidationRegex.MatchString(*socketID) {
 		return
-	} else {
-		return errors.New("socket_id invalid")
 	}
+	return errors.New("socket_id invalid")
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -23,36 +23,36 @@ func TestClientWebhookValidation(t *testing.T) {
 
 func TestWebhookImproperKeyCase(t *testing.T) {
 	client := setUpClient()
-	bad_header := make(http.Header)
-	bad_header["X-Pusher-Key"] = []string{"narr you're going down!"}
-	bad_header["X-Pusher-Signature"] = []string{"2677ad3e7c090b2fa2c0fb13020d66d5420879b8316eb356a2d60fb9073bc778"}
-	bad_body := []byte("{\"hello\":\"world\"}")
+	badHeader := make(http.Header)
+	badHeader["X-Pusher-Key"] = []string{"narr you're going down!"}
+	badHeader["X-Pusher-Signature"] = []string{"2677ad3e7c090b2fa2c0fb13020d66d5420879b8316eb356a2d60fb9073bc778"}
+	badBody := []byte("{\"hello\":\"world\"}")
 
-	bad_webhook, err := client.Webhook(bad_header, bad_body)
-	assert.Nil(t, bad_webhook)
+	badWebhook, err := client.Webhook(badHeader, badBody)
+	assert.Nil(t, badWebhook)
 	assert.Error(t, err)
 }
 
 func TestWebhookImproperSignatureCase(t *testing.T) {
 	client := setUpClient()
-	bad_header := make(http.Header)
-	bad_header["X-Pusher-Key"] = []string{"key"}
-	bad_header["X-Pusher-Signature"] = []string{"2677ad3e7c090i'mgonnagetyaeb356a2d60fb9073bc778"}
-	bad_body := []byte("{\"hello\":\"world\"}")
+	badHeader := make(http.Header)
+	badHeader["X-Pusher-Key"] = []string{"key"}
+	badHeader["X-Pusher-Signature"] = []string{"2677ad3e7c090i'mgonnagetyaeb356a2d60fb9073bc778"}
+	badBody := []byte("{\"hello\":\"world\"}")
 
-	bad_webhook, err := client.Webhook(bad_header, bad_body)
-	assert.Nil(t, bad_webhook)
+	badWebhook, err := client.Webhook(badHeader, badBody)
+	assert.Nil(t, badWebhook)
 	assert.Error(t, err)
 }
 
 func TestWebhookNoSignature(t *testing.T) {
 	client := setUpClient()
-	bad_header := make(http.Header)
-	bad_header["X-Pusher-Key"] = []string{"key"}
-	bad_body := []byte("{\"hello\":\"world\"}")
+	badHeader := make(http.Header)
+	badHeader["X-Pusher-Key"] = []string{"key"}
+	badBody := []byte("{\"hello\":\"world\"}")
 
-	bad_webhook, err := client.Webhook(bad_header, bad_body)
-	assert.Nil(t, bad_webhook)
+	badWebhook, err := client.Webhook(badHeader, badBody)
+	assert.Nil(t, badWebhook)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
There is no API changes introduced in this PR.
It is mostly about:
- using camel case variable instead of snake case(with underscore)
- no `else` needed when `if` return
- change `Id` to `ID`, `Url` to `URL` 

golint result before and after this PR can be seen below

before
```
#golint *.go
channel_authentication_test.go:17:2: don't use underscores in Go names; var post_params should be postParams
channel_authentication_test.go:26:2: don't use underscores in Go names; var post_params should be postParams
channel_authentication_test.go:33:2: don't use underscores in Go names; var post_params should be postParams
channel_authentication_test.go:34:2: don't use underscores in Go names; var presence_data should be presenceData
client.go:43:2: struct field AppId should be AppID
client.go:49:2: struct field HttpClient should be HTTPClient
client.go:52:1: comment on exported function ClientFromURL should be of the form "ClientFromURL ..."
client.go:91:1: comment on exported function ClientFromEnv should be of the form "ClientFromEnv ..."
client.go:119:1: comment on exported method Client.Trigger should be of the form "Trigger ..."
client.go:135:1: comment on exported method Client.TriggerMulti should be of the form "TriggerMulti ..."
client.go:144:1: comment on exported method Client.TriggerExclusive should be of the form "TriggerExclusive ..."
client.go:155:1: comment on exported method Client.TriggerMultiExclusive should be of the form "TriggerMultiExclusive ..."
client.go:165:77: method parameter socketId should be socketID
client.go:193:1: comment on exported method Client.Channels should be of the form "Channels ..."
client.go:220:1: comment on exported method Client.Channel should be of the form "Channel ..."
client.go:247:1: comment on exported method Client.GetChannelUsers should be of the form "GetChannelUsers ..."
client.go:265:1: comment on exported method Client.AuthenticatePrivateChannel should be of the form "AuthenticatePrivateChannel ..."
client.go:308:1: comment on exported method Client.AuthenticatePresenceChannel should be of the form "AuthenticatePresenceChannel ..."
client.go:338:15: var socketId should be socketID
client.go:373:1: comment on exported method Client.Webhook should be of the form "Webhook ..."
client_test.go:21:3: don't use underscores in Go names; var expected_body should be expectedBody
client_test.go:22:3: don't use underscores in Go names; var actual_body should be actualBody
client_test.go:114:3: don't use underscores in Go names; var expected_body should be expectedBody
client_test.go:115:3: don't use underscores in Go names; var actual_body should be actualBody
doc.go:1:1: package comment should be of the form "Package pusher ..."
event.go:12:2: struct field SocketId should be SocketID
event.go:15:6: exported type BufferedEvents should have comment or be unexported
event.go:19:78: func parameter socketId should be socketID
request.go:34:9: if block ends with a return statement, so drop this else and outdent its block
request_url.go:31:6: func unescapeUrl should be unescapeURL
request_url.go:36:6: func createRequestUrl should be createRequestURL
request_url_test.go:38:2: don't use underscores in Go names; var additional_queries should be additionalQueries
request_url_test.go:45:2: don't use underscores in Go names; var additional_queries should be additionalQueries
request_url_test.go:52:2: don't use underscores in Go names; var additional_queries should be additionalQueries
request_url_test.go:59:2: don't use underscores in Go names; var additional_queries should be additionalQueries
response_parsing.go:7:1: comment on exported type Channel should be of the form "Channel ..." (with optional leading article)
response_parsing.go:15:1: comment on exported type ChannelsList should be of the form "ChannelsList ..." (with optional leading article)
response_parsing.go:20:1: comment on exported type ChannelListItem should be of the form "ChannelListItem ..." (with optional leading article)
response_parsing.go:25:1: comment on exported type Users should be of the form "Users ..." (with optional leading article)
response_parsing.go:30:1: comment on exported type User should be of the form "User ..." (with optional leading article)
response_parsing.go:32:2: struct field Id should be ID
response_parsing.go:35:1: comment on exported type MemberData should be of the form "MemberData ..." (with optional leading article)
response_parsing.go:39:2: struct field UserId should be UserID
util.go:12:5: var socketIdValidationRegex should be socketIDValidationRegex
util.go:46:6: func validateSocketId should be validateSocketID
util.go:46:23: func parameter socketId should be socketID
util.go:49:9: if block ends with a return statement, so drop this else and outdent its block
webhook.go:7:1: comment on exported type Webhook should be of the form "Webhook ..." (with optional leading article)
webhook.go:13:6: exported type WebhookEvent should have comment or be unexported
webhook.go:18:2: struct field SocketId should be SocketID
webhook.go:19:2: struct field UserId should be UserID
webhook_test.go:26:2: don't use underscores in Go names; var bad_header should be badHeader
webhook_test.go:29:2: don't use underscores in Go names; var bad_body should be badBody
webhook_test.go:31:2: don't use underscores in Go names; var bad_webhook should be badWebhook
webhook_test.go:38:2: don't use underscores in Go names; var bad_header should be badHeader
webhook_test.go:41:2: don't use underscores in Go names; var bad_body should be badBody
webhook_test.go:43:2: don't use underscores in Go names; var bad_webhook should be badWebhook
webhook_test.go:50:2: don't use underscores in Go names; var bad_header should be badHeader
webhook_test.go:52:2: don't use underscores in Go names; var bad_body should be badBody
webhook_test.go:54:2: don't use underscores in Go names; var bad_webhook should be badWebhook
```

After
```
#golint *.go
client.go:43:2: struct field AppId should be AppID
client.go:49:2: struct field HttpClient should be HTTPClient
client.go:52:1: comment on exported function ClientFromURL should be of the form "ClientFromURL ..."
client.go:91:1: comment on exported function ClientFromEnv should be of the form "ClientFromEnv ..."
client.go:119:1: comment on exported method Client.Trigger should be of the form "Trigger ..."
client.go:135:1: comment on exported method Client.TriggerMulti should be of the form "TriggerMulti ..."
client.go:144:1: comment on exported method Client.TriggerExclusive should be of the form "TriggerExclusive ..."
client.go:155:1: comment on exported method Client.TriggerMultiExclusive should be of the form "TriggerMultiExclusive ..."
client.go:193:1: comment on exported method Client.Channels should be of the form "Channels ..."
client.go:220:1: comment on exported method Client.Channel should be of the form "Channel ..."
client.go:247:1: comment on exported method Client.GetChannelUsers should be of the form "GetChannelUsers ..."
client.go:265:1: comment on exported method Client.AuthenticatePrivateChannel should be of the form "AuthenticatePrivateChannel ..."
client.go:308:1: comment on exported method Client.AuthenticatePresenceChannel should be of the form "AuthenticatePresenceChannel ..."
client.go:373:1: comment on exported method Client.Webhook should be of the form "Webhook ..."
doc.go:1:1: package comment should be of the form "Package pusher ..."
event.go:12:2: struct field SocketId should be SocketID
event.go:15:6: exported type BufferedEvents should have comment or be unexported
response_parsing.go:7:1: comment on exported type Channel should be of the form "Channel ..." (with optional leading article)
response_parsing.go:15:1: comment on exported type ChannelsList should be of the form "ChannelsList ..." (with optional leading article)
response_parsing.go:20:1: comment on exported type ChannelListItem should be of the form "ChannelListItem ..." (with optional leading article)
response_parsing.go:25:1: comment on exported type Users should be of the form "Users ..." (with optional leading article)
response_parsing.go:30:1: comment on exported type User should be of the form "User ..." (with optional leading article)
response_parsing.go:32:2: struct field Id should be ID
response_parsing.go:35:1: comment on exported type MemberData should be of the form "MemberData ..." (with optional leading article)
response_parsing.go:39:2: struct field UserId should be UserID
webhook.go:7:1: comment on exported type Webhook should be of the form "Webhook ..." (with optional leading article)
webhook.go:13:6: exported type WebhookEvent should have comment or be unexported
webhook.go:18:2: struct field SocketId should be SocketID
webhook.go:19:2: struct field UserId should be UserID
```