### PR TITLE
Don't panic on invalid createRequestURL paths

### DIFF
--- a/client.go
+++ b/client.go
@@ -181,7 +181,10 @@ func (c *Client) trigger(channels []string, eventName string, data interface{}, 
 	}
 
 	path := fmt.Sprintf("/apps/%s/events", c.AppId)
-	u := createRequestURL("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, payload, nil, c.Cluster)
+	u, err := createRequestURL("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, payload, nil, c.Cluster)
+	if err != nil {
+		return nil, err
+	}
 	response, err := c.request("POST", u, payload)
 	if err != nil {
 		return nil, err
@@ -201,7 +204,10 @@ func (c *Client) TriggerBatch(batch []Event) (*BufferedEvents, error) {
 	}
 
 	path := fmt.Sprintf("/apps/%s/batch_events", c.AppId)
-	u := createRequestURL("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, payload, nil, c.Cluster)
+	u, err := createRequestURL("POST", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, payload, nil, c.Cluster)
+	if err != nil {
+		return nil, err
+	}
 	response, err := c.request("POST", u, payload)
 	if err != nil {
 		return nil, err
@@ -229,7 +235,10 @@ specify an `"info"` key with value `"user_count"`. Pass in `nil` if you do not w
 */
 func (c *Client) Channels(additionalQueries map[string]string) (*ChannelsList, error) {
 	path := fmt.Sprintf("/apps/%s/channels", c.AppId)
-	u := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
+	u, err := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
+	if err != nil {
+		return nil, err
+	}
 	response, err := c.request("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -256,7 +265,10 @@ if you wish to enable this. Pass in `nil` if you do not wish to specify any quer
 */
 func (c *Client) Channel(name string, additionalQueries map[string]string) (*Channel, error) {
 	path := fmt.Sprintf("/apps/%s/channels/%s", c.AppId, name)
-	u := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
+	u, err := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, additionalQueries, c.Cluster)
+	if err != nil {
+		return nil, err
+	}
 	response, err := c.request("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -274,7 +286,10 @@ Get a list of users in a presence-channel by passing to this method the channel 
 */
 func (c *Client) GetChannelUsers(name string) (*Users, error) {
 	path := fmt.Sprintf("/apps/%s/channels/%s/users", c.AppId, name)
-	u := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, nil, c.Cluster)
+	u, err := createRequestURL("GET", c.Host, path, c.Key, c.Secret, authTimestamp(), c.Secure, nil, nil, c.Cluster)
+	if err != nil {
+		return nil, err
+	}
 	response, err := c.request("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/request_url.go
+++ b/request_url.go
@@ -33,7 +33,7 @@ func unescapeURL(_url url.Values) string {
 	return unesc
 }
 
-func createRequestURL(method, host, path, key, secret, timestamp string, secure bool, body []byte, additionalQueries map[string]string, cluster string) string {
+func createRequestURL(method, host, path, key, secret, timestamp string, secure bool, body []byte, additionalQueries map[string]string, cluster string) (string, error) {
 	params := unsignedParams(key, timestamp, body, additionalQueries)
 
 	stringToSign := strings.Join([]string{method, path, unescapeURL(params)}, "\n")
@@ -57,11 +57,11 @@ func createRequestURL(method, host, path, key, secret, timestamp string, secure 
 	}
 	base += host
 
-	endpoint, err := url.Parse(base + path)
+	endpoint, err := url.ParseRequestURI(base + path)
 	if err != nil {
-		panic("logic error: " + err.Error())
+		return "", err
 	}
 	endpoint.RawQuery = unescapeURL(params)
 
-	return endpoint.String()
+	return endpoint.String(), nil
 }

--- a/request_url_test.go
+++ b/request_url_test.go
@@ -8,61 +8,67 @@ import (
 func TestTriggerRequestUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
+	result, _ := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestBuildClusterTriggerUrl(t *testing.T) {
 	expected := "http://api-eu.pusher.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "eu")
+	result, _ := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "eu")
 	assert.Equal(t, expected, result)
 }
 
 func TestBuildCustomHostTriggerUrl(t *testing.T) {
 	expected := "http://my.server.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestURL("POST", "my.server.com", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
+	result, _ := createRequestURL("POST", "my.server.com", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", false, payload, nil, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestTriggerSecureRequestUrl(t *testing.T) {
 	expected := "https://api.pusherapp.com/apps/3/events?auth_key=278d425bdf160c739803&auth_signature=da454824c97ba181a32ccc17a72625ba02771f50b50e1e7430e47a1f3f457e6c&auth_timestamp=1353088179&auth_version=1.0&body_md5=ec365a775a4cd0599faeb73354201b6f"
 	payload := []byte("{\"name\":\"foo\",\"channels\":[\"project-3\"],\"data\":\"{\\\"some\\\":\\\"data\\\"}\"}")
-	result := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", true, payload, nil, "")
+	result, _ := createRequestURL("POST", "", "/apps/3/events", "278d425bdf160c739803", "7ad3773142a6692b25b8", "1353088179", true, payload, nil, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetAllChannelsUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels?auth_key=d41a439c438a100756f5&auth_signature=4d8a02edcc8a758b0162cd6da690a9a45fb8ae326a276dca1e06a0bc42796c11&auth_timestamp=1427034994&auth_version=1.0&filter_by_prefix=presence-&info=user_count"
 	additionalQueries := map[string]string{"filter_by_prefix": "presence-", "info": "user_count"}
-	result := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427034994", false, nil, additionalQueries, "")
+	result, _ := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427034994", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetAllChannelsWithOneAdditionalParamUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels?auth_key=d41a439c438a100756f5&auth_signature=b540383af4582af5fbb5df7be5472d54bd0838c9c2021c7743062568839e6f97&auth_timestamp=1427036577&auth_version=1.0&filter_by_prefix=presence-"
 	additionalQueries := map[string]string{"filter_by_prefix": "presence-"}
-	result := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036577", false, nil, additionalQueries, "")
+	result, _ := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036577", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetAllChannelsWithNoParamsUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels?auth_key=d41a439c438a100756f5&auth_signature=df89248f87f6e6d028925e0b04d60f316527a865992ace6936afa91281d8bef0&auth_timestamp=1427036787&auth_version=1.0"
 	additionalQueries := map[string]string{}
-	result := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036787", false, nil, additionalQueries, "")
+	result, _ := createRequestURL("GET", "", "/apps/102015/channels", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427036787", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetChannelUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-ROpCFmgFhXY?auth_key=d41a439c438a100756f5&auth_signature=f93ceb31f396aef336226efe512aaf339bd5e39c7c2c04b81cc8681dc16ee785&auth_timestamp=1427053326&auth_version=1.0&info=user_count,subscription_count"
 	additionalQueries := map[string]string{"info": "user_count,subscription_count"}
-	result := createRequestURL("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-ROpCFmgFhXY", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053326", false, nil, additionalQueries, "")
+	result, _ := createRequestURL("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-ROpCFmgFhXY", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053326", false, nil, additionalQueries, "")
 	assert.Equal(t, expected, result)
 }
 
 func TestGetUsersUrl(t *testing.T) {
 	expected := "http://api.pusherapp.com/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-nYJLy67qh52/users?auth_key=d41a439c438a100756f5&auth_signature=207feaf4e8efeb24e5f148011704251bf90e2059a5f97a3eb52d06178b11feca&auth_timestamp=1427053709&auth_version=1.0"
-	result := createRequestURL("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-nYJLy67qh52/users", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053709", false, nil, nil, "")
+	result, _ := createRequestURL("GET", "", "/apps/102015/channels/presence-session-d41a439c438a100756f5-4bf35003e819bb138249-nYJLy67qh52/users", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053709", false, nil, nil, "")
 	assert.Equal(t, expected, result)
+}
+
+func TestBrokenUrl(t *testing.T) {
+	result, err := createRequestURL("GET", "", "#foo", "d41a439c438a100756f5", "4bf35003e819bb138249", "1427053709", false, nil, nil, "")
+	assert.Error(t, err)
+	assert.Equal(t, "", result)
 }


### PR DESCRIPTION
panics are harder to catch and should probably never be used in client
libraries.

This also strenghten the url parsing to the subset valid for requests.

/cc @jpatel531 