### PR TITLE
replace /customer_api with /server_api

### DIFF
--- a/requests/requests.go
+++ b/requests/requests.go
@@ -31,5 +31,5 @@ var ChannelUsers = &Request{
 
 var NativePush = &Request{
 	Method:      http.MethodPost,
-	PathPattern: "/customer_api/v1/apps/%s/notifications",
+	PathPattern: "/server_api/v1/apps/%s/notifications",
 }


### PR DESCRIPTION
`/customer_api` is now deprecated.

CC @jpatel531 