### PR TITLE
Add missing err check when pushing a notification

### DIFF
--- a/client.go
+++ b/client.go
@@ -474,6 +474,9 @@ func (c *Client) Notify(interests []string, pushNotification PushNotification) (
 	}
 
 	byteResponse, err := c.request("POST", url, requestBody)
+	if err != nil {
+		return nil, err
+	}
 
 	var response *NotifyResponse
 	err = json.Unmarshal(byteResponse, &response)

--- a/client_test.go
+++ b/client_test.go
@@ -349,6 +349,7 @@ func TestNotifyServerError(t *testing.T) {
 
 	assert.Nil(t, response, "response should return nil on error")
 	assert.Error(t, err)
+	assert.EqualError(t, err, "Status Code: 500 - ")
 }
 
 func TestNotifyInvalidPushNotification(t *testing.T) {


### PR DESCRIPTION
It wasn't there.

And then the error would end up being something about how it failed to unmarshal a JSON, which was a bit misleading...