### PR TITLE
Add End-to-end encryption for TriggerBatch

### DIFF
--- a/channel_authentication_test.go
+++ b/channel_authentication_test.go
@@ -1,8 +1,9 @@
 package pusher
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func setUpAuthClient() Client {

--- a/client.go
+++ b/client.go
@@ -14,6 +14,7 @@ import (
 )
 
 var pusherPathRegex = regexp.MustCompile("^/apps/([0-9]+)$")
+var maxTriggerableChannels = 100
 
 /*
 Client to the HTTP API of Pusher.
@@ -138,7 +139,7 @@ func (c *Client) Trigger(channel string, eventName string, data interface{}) (*B
 
 /*
 The same as `client.Trigger`, except one passes in a slice of `channels` as the first parameter.
-The maximum length of channels is 10.
+The maximum length of channels is 100.
 	client.TriggerMulti([]string{"a_channel", "another_channel"}, "event", data)
 */
 func (c *Client) TriggerMulti(channels []string, eventName string, data interface{}) (*BufferedEvents, error) {
@@ -167,8 +168,8 @@ func (c *Client) TriggerMultiExclusive(channels []string, eventName string, data
 }
 
 func (c *Client) trigger(channels []string, eventName string, data interface{}, socketID *string) (*BufferedEvents, error) {
-	if len(channels) > 10 {
-		return nil, errors.New("You cannot trigger on more than 10 channels at once")
+	if len(channels) > maxTriggerableChannels {
+		return nil, fmt.Errorf("You cannot trigger on more than %d channels at once", maxTriggerableChannels)
 	}
 
 	if len(channels) > 1 && encryptedChannelPresent(channels) {

--- a/client.go
+++ b/client.go
@@ -172,14 +172,16 @@ func (c *Client) trigger(channels []string, eventName string, data interface{}, 
 	}
 
 	if len(channels) > 1 && encryptedChannelPresent(channels) {
-		return nil, errors.New("You cannot trigger batch events when using encrypted channels")
+		// For rationale, see limitations of end-to-end encryption in the README
+		return nil, errors.New("You cannot trigger to multiple channels when using encrypted channels")
 	}
 
 	if !channelsAreValid(channels) {
 		return nil, errors.New("At least one of your channels' names are invalid")
 	}
+
 	if !validEncryptionKey(c.EncryptionMasterKey) && encryptedChannelPresent(channels) {
-		return nil, errors.New("Your Encryption key is not of the correct format")
+		return nil, errors.New("Your encryptionMasterKey is not of the correct format")
 	}
 
 	if err := validateSocketID(socketID); err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -196,12 +196,23 @@ func TestRequestTimeouts(t *testing.T) {
 }
 
 func TestChannelLengthValidation(t *testing.T) {
-	channels := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}
+	channels := []string{
+		"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11",
+		"12", "13", "14", "15", "16", "17", "18", "19", "20", "21",
+		"22", "23", "24", "25", "26", "27", "28", "29", "30", "31",
+		"32", "33", "34", "35", "36", "37", "38", "39", "40", "41",
+		"42", "43", "44", "45", "46", "47", "48", "49", "50", "51",
+		"52", "53", "54", "55", "56", "57", "58", "59", "60", "61",
+		"62", "63", "64", "65", "66", "67", "68", "69", "70", "71",
+		"72", "73", "74", "75", "76", "77", "78", "79", "80", "81",
+		"82", "83", "84", "85", "86", "87", "88", "89", "90", "91",
+		"92", "93", "94", "95", "96", "97", "98", "99", "100", "101",
+	}
 
 	client := Client{AppId: "id", Key: "key", Secret: "secret"}
 	res, err := client.TriggerMulti(channels, "yolo", "woot")
 
-	assert.EqualError(t, err, "You cannot trigger on more than 10 channels at once")
+	assert.EqualError(t, err, "You cannot trigger on more than 100 channels at once")
 	assert.Nil(t, res)
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -130,7 +130,7 @@ func TestTriggerSocketIdValidation(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestTriggerBatch(t *testing.T) {
+func TestTriggerBatchSuccess(t *testing.T) {
 	expectedBody := `{"batch":[{"channel":"test_channel","name":"test","data":"yolo1"},{"channel":"test_channel","name":"test","data":"yolo2"}]}`
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(200)
@@ -151,6 +151,83 @@ func TestTriggerBatch(t *testing.T) {
 	_, err := client.TriggerBatch([]Event{
 		{"test_channel", "test", "yolo1", nil},
 		{"test_channel", "test", "yolo2", nil},
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestTriggerBatchWithEncryptionMasterKeyNoEncryptedChanSuccess(t *testing.T) {
+	expectedBody := `{"batch":[{"channel":"test_channel","name":"test","data":"yolo1"},{"channel":"test_channel","name":"test","data":"yolo2"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(200)
+		fmt.Fprintf(res, "{}")
+		assert.Equal(t, "POST", req.Method)
+
+		actualBody, err := ioutil.ReadAll(req.Body)
+		assert.Equal(t, expectedBody, string(actualBody))
+		assert.Equal(t, "application/json", req.Header["Content-Type"][0])
+		assert.Equal(t, "/apps/appid/batch_events", req.URL.Path)
+		assert.NoError(t, err)
+
+	}))
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	client := Client{AppId: "appid", Key: "key", Secret: "secret", EncryptionMasterKey: "eHPVWHg7nFGYVBsKjOFDXWRribIR2b0b", Host: u.Host}
+
+	_, err := client.TriggerBatch([]Event{
+		{"test_channel", "test", "yolo1", nil},
+		{"test_channel", "test", "yolo2", nil},
+	})
+
+	assert.NoError(t, err)
+}
+
+func TestTriggerBatchNoEncryptionMasterKeyWithEncryptedChanFailure(t *testing.T) {
+	expectedBody := `{"batch":[{"channel":"test_channel","name":"test","data":"yolo1"},{"channel":"private-encrypted-test_channel","name":"test","data":"yolo2"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(200)
+		fmt.Fprintf(res, "{}")
+		assert.Equal(t, "POST", req.Method)
+
+		actualBody, err := ioutil.ReadAll(req.Body)
+		assert.Equal(t, expectedBody, string(actualBody))
+		assert.Equal(t, "application/json", req.Header["Content-Type"][0])
+		assert.Equal(t, "/apps/appid/batch_events", req.URL.Path)
+		assert.NoError(t, err)
+
+	}))
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	client := Client{AppId: "appid", Key: "key", Secret: "secret", Host: u.Host}
+
+	_, err := client.TriggerBatch([]Event{
+		{"test_channel", "test", "yolo1", nil},
+		{"private-encrypted-test_channel", "test", "yolo2", nil},
+	})
+
+	assert.Error(t, err)
+}
+
+func TestTriggerBatchWithEncryptedChanSuccess(t *testing.T) {
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(200)
+		fmt.Fprintf(res, "{}")
+		assert.Equal(t, "POST", req.Method)
+
+		_, err := ioutil.ReadAll(req.Body)
+		assert.Equal(t, "application/json", req.Header["Content-Type"][0])
+		assert.Equal(t, "/apps/appid/batch_events", req.URL.Path)
+		assert.NoError(t, err)
+
+	}))
+	defer server.Close()
+	u, _ := url.Parse(server.URL)
+	client := Client{AppId: "appid", Key: "key", Secret: "secret", EncryptionMasterKey: "eHPVWHg7nFGYVBsKjOFDXWRribIR2b0b", Host: u.Host}
+
+	_, err := client.TriggerBatch([]Event{
+		{"test_channel", "test", "yolo1", nil},
+		{"private-encrypted-test_channel", "test", "yolo2", nil},
 	})
 
 	assert.NoError(t, err)

--- a/crypto.go
+++ b/crypto.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/crypto/nacl/secretbox"
 )
 
+// EncryptedMessage contains an encrypted message
 type EncryptedMessage struct {
 	Nonce      string `json:"nonce"`
 	Ciphertext string `json:"ciphertext"`

--- a/event.go
+++ b/event.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 )
 
+// maxEventPayloadSize indicates the max size allowed for the data content (payload) of each event
+const maxEventPayloadSize = 10240
+
 type Event struct {
 	Channel  string  `json:"channel"`
 	Name     string  `json:"name"`
@@ -45,7 +48,7 @@ func createTriggerPayload(channels []string, event string, data interface{}, soc
 		payloadData = string(dataBytes)
 	}
 
-	if len(payloadData) > 10240 {
+	if len(payloadData) > maxEventPayloadSize {
 		return nil, errors.New("Data must be smaller than 10kb")
 	}
 	return json.Marshal(&eventPayload{

--- a/event.go
+++ b/event.go
@@ -27,21 +27,13 @@ type BufferedEvents struct {
 }
 
 func createTriggerPayload(channels []string, event string, data interface{}, socketID *string, encryptionKey string) ([]byte, error) {
-	var dataBytes []byte
-	var err error
-	var payloadData string
 
-	switch d := data.(type) {
-	case []byte:
-		dataBytes = d
-	case string:
-		dataBytes = []byte(d)
-	default:
-		dataBytes, err = json.Marshal(data)
-		if err != nil {
-			return nil, err
-		}
+	dataBytes, err := byteEncodePayload(data)
+	if err != nil {
+		return nil, err
 	}
+
+	var payloadData string
 	if isEncryptedChannel(channels[0]) {
 		payloadData = encrypt(channels[0], dataBytes, encryptionKey)
 	} else {
@@ -57,4 +49,22 @@ func createTriggerPayload(channels []string, event string, data interface{}, soc
 		Data:     payloadData,
 		SocketId: socketID,
 	})
+}
+
+func byteEncodePayload(data interface{}) ([]byte, error) {
+	var dataBytes []byte
+	var err error
+
+	switch d := data.(type) {
+	case []byte:
+		dataBytes = d
+	case string:
+		dataBytes = []byte(d)
+	default:
+		dataBytes, err = json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return dataBytes, nil
 }

--- a/util.go
+++ b/util.go
@@ -44,14 +44,6 @@ func channelsAreValid(channels []string) bool {
 	}
 	return true
 }
-func encryptedChannelPresent(channels []string) bool {
-	for _, channel := range channels {
-		if isEncryptedChannel(channel) {
-			return true
-		}
-	}
-	return false
-}
 
 func isEncryptedChannel(channel string) bool {
 	if strings.HasPrefix(channel, "private-encrypted-") {

--- a/util.go
+++ b/util.go
@@ -11,6 +11,7 @@ import (
 
 var channelValidationRegex = regexp.MustCompile("^[-a-zA-Z0-9_=@,.;]+$")
 var socketIDValidationRegex = regexp.MustCompile(`\A\d+\.\d+\z`)
+var maxChannelNameSize = 200
 
 func authTimestamp() string {
 	return strconv.FormatInt(time.Now().Unix(), 10)
@@ -37,7 +38,7 @@ func parseAuthRequestParams(_params []byte) (channelName string, socketID string
 
 func channelsAreValid(channels []string) bool {
 	for _, channel := range channels {
-		if len(channel) > 200 || !channelValidationRegex.MatchString(channel) {
+		if len(channel) > maxChannelNameSize || !channelValidationRegex.MatchString(channel) {
 			return false
 		}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -1,8 +1,9 @@
 package pusher
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseAuthRequestParamsNoSock(t *testing.T) {


### PR DESCRIPTION
- It adds missing End-to-end encryption support for TriggerBatch
- it adds small refactors and moves hardcoded values into easy modifiable constants
- It updates the max number of triggerable channels from 10 to 100 (as per official documentation of Pusher)