### PR TITLE
Refactor TriggerBatch's Event.Data string -> interface

### DIFF
--- a/event.go
+++ b/event.go
@@ -10,10 +10,10 @@ import (
 const maxEventPayloadSize = 10240
 
 type Event struct {
-	Channel  string  `json:"channel"`
-	Name     string  `json:"name"`
-	Data     string  `json:"data"`
-	SocketId *string `json:"socket_id,omitempty"`
+	Channel  string      `json:"channel"`
+	Name     string      `json:"name"`
+	Data     interface{} `json:"data"`
+	SocketId *string     `json:"socket_id,omitempty"`
 }
 
 type eventPayload struct {
@@ -60,7 +60,7 @@ func createTriggerBatchPayload(batch []Event, encryptionKey string) ([]byte, err
 		} else {
 			batch[idx].Data = string(dataBytes)
 		}
-		if len(batch[idx].Data) > maxEventPayloadSize {
+		if len(batch[idx].Data.(string)) > maxEventPayloadSize {
 			return nil, fmt.Errorf("Data of the event #%d in batch, must be smaller than 10kb", idx)
 		}
 	}


### PR DESCRIPTION
It refactors TriggerBatch's API by modifying the accepted type Event.Data to be consistent with the Trigger's API.

This is obtained by switching from a `string` type to a `interface{}` type. This approach, in fact, allows any matching type to be passed in as a Payload, which is desirable as we do not want to limit the users to strings only.