### PR TITLE
Refactor Trigger/TriggerBatch encoding related functions, filenames and types

### DIFF
--- a/client.go
+++ b/client.go
@@ -190,7 +190,7 @@ func (c *Client) trigger(channels []string, eventName string, data interface{}, 
 	if err := validateSocketID(socketID); err != nil {
 		return nil, err
 	}
-	payload, err := createTriggerPayload(channels, eventName, data, socketID, c.EncryptionMasterKey)
+	payload, err := encodeTriggerBody(channels, eventName, data, socketID, c.EncryptionMasterKey)
 	if err != nil {
 		return nil, err
 	}
@@ -206,8 +206,11 @@ func (c *Client) trigger(channels []string, eventName string, data interface{}, 
 	return unmarshalledBufferedEvents(response)
 }
 
-type batchRequest struct {
-	Batch []Event `json:"batch"`
+type Event struct {
+	Channel  string
+	Name     string
+	Data     interface{}
+	SocketId *string
 }
 
 /* TriggerBatch triggers multiple events on multiple types of channels in a single call:
@@ -236,7 +239,7 @@ func (c *Client) TriggerBatch(batch []Event) (*BufferedEvents, error) {
 			return nil, errors.New("Your encryptionMasterKey is not of the correct format")
 		}
 	}
-	payload, err := createTriggerBatchPayload(batch, c.EncryptionMasterKey)
+	payload, err := encodeTriggerBatchBody(batch, c.EncryptionMasterKey)
 	if err != nil {
 		return nil, err
 	}

--- a/encoder.go
+++ b/encoder.go
@@ -74,7 +74,7 @@ func encodeTriggerBatchBody(batch []Event, encryptionKey string) ([]byte, error)
 			Data:     stringifyedDataBytes,
 			SocketId: e.SocketId,
 		}
-		batchEvents = append(batchEvents, newBatchEvent)
+		batchEvents[idx] = newBatchEvent
 	}
 	return json.Marshal(&batchPayload{batchEvents})
 }

--- a/encoder.go
+++ b/encoder.go
@@ -53,7 +53,7 @@ func encodeTriggerBody(channels []string, event string, data interface{}, socket
 }
 
 func encodeTriggerBatchBody(batch []Event, encryptionKey string) ([]byte, error) {
-	var batchEvents []batchEvent
+ 	batchEvents := make([]batchEvent, len(batch))
 	for idx, e := range batch {
 		var stringifyedDataBytes string
 		dataBytes, err := encodeEventData(e.Data)


### PR DESCRIPTION
- it refactors Trigger/TriggerBatch encoding logic filename from event.go -> encoder.go
- it refactors Trigger/TriggerBatch encoding logic functions names and types to more meaningful ones.
- it changes Trigger/TriggerBatch encoding logic types going from a single source->destination type to one source type and one destination type.