### PR TITLE
Allow larger requests as we sometimes do on dedicated clusters

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -512,13 +513,10 @@ func TestChannelFormatValidation(t *testing.T) {
 
 func TestDataSizeValidation(t *testing.T) {
 	client := Client{AppID: "id", Key: "key", Secret: "secret"}
-	var data string
-	for i := 0; i <= 10242; i++ {
-		data += "a"
-	}
+	data := strings.Repeat("a", 20481)
 	err := client.Trigger("channel", "event", data)
 
-	assert.EqualError(t, err, "Data must be smaller than 10kb")
+	assert.EqualError(t, err, "Event payload exceeded maximum size")
 
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -516,8 +516,7 @@ func TestDataSizeValidation(t *testing.T) {
 	data := strings.Repeat("a", 20481)
 	err := client.Trigger("channel", "event", data)
 
-	assert.EqualError(t, err, "Event payload exceeded maximum size")
-
+	assert.EqualError(t, err, "Event payload exceeded maximum size (20481 bytes is too much)")
 }
 
 func TestInitialisationFromURL(t *testing.T) {

--- a/encoder.go
+++ b/encoder.go
@@ -38,7 +38,7 @@ func encodeTriggerBody(channels []string, event string, data interface{}, socket
 		payloadData = string(dataBytes)
 	}
 	if len(payloadData) > maxEventPayloadSize {
-		return nil, errors.New("Event payload exceeded maximum size")
+		return nil, errors.New(fmt.Sprintf("Event payload exceeded maximum size (%d bytes is too much)", len(payloadData)))
 	}
 	return json.Marshal(&eventPayload{
 		Name:     event,

--- a/encoder.go
+++ b/encoder.go
@@ -7,7 +7,7 @@ import (
 )
 
 // maxEventPayloadSize indicates the max size allowed for the data content (payload) of each event
-const maxEventPayloadSize = 10240
+const maxEventPayloadSize = 20480 // on dedicated clusters we may allow 2x the usual limit
 
 type batchEvent struct {
 	Channel  string  `json:"channel"`
@@ -38,7 +38,7 @@ func encodeTriggerBody(channels []string, event string, data interface{}, socket
 		payloadData = string(dataBytes)
 	}
 	if len(payloadData) > maxEventPayloadSize {
-		return nil, errors.New("Data must be smaller than 10kb")
+		return nil, errors.New("Event payload exceeded maximum size")
 	}
 	return json.Marshal(&eventPayload{
 		Name:     event,


### PR DESCRIPTION
## Why?

While most customers will get requests reject if bigger than 10KB, we can let the server handle those errors. We don't want to allow bigger than 20KB due to bandwidth and overall cluster latency considerations, so we can move the hardcoded limit to match this.