### PR TITLE
Allow message limit to be overridden for dedicate cluster customers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+4.0.4 / 2020-09-02
+==================
+* Allow message size to be overridden for dedicate cluster customers (PR [#63](https://github.com/pusher/pusher-http-go/pull/71))
+
 4.0.3 / 2020-07-28
 ==================
 * Added library name and version in HTTP Header (PR [#62](https://github.com/pusher/pusher-http-go/pull/62))

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ var pusherPathRegex = regexp.MustCompile("^/apps/([0-9]+)$")
 var maxTriggerableChannels = 100
 
 const (
-	libraryVersion = "4.0.3"
+	libraryVersion = "4.0.4"
 	libraryName    = "pusher-http-go"
 )
 
@@ -58,6 +58,7 @@ type Client struct {
 	HTTPClient                   *http.Client
 	EncryptionMasterKey          string  // deprecated
 	EncryptionMasterKeyBase64    string  // for E2E
+	OverrideMaxMessagePayloadKB  int     // set the agreed Pusher message limit increase
 	validatedEncryptionMasterKey *[]byte // parsed key for use
 }
 
@@ -200,7 +201,7 @@ func (c *Client) trigger(channels []string, eventName string, data interface{}, 
 		return err
 	}
 
-	payload, err := encodeTriggerBody(channels, eventName, data, socketID, masterKey)
+	payload, err := encodeTriggerBody(channels, eventName, data, socketID, masterKey, c.OverrideMaxMessagePayloadKB)
 	if err != nil {
 		return err
 	}
@@ -250,7 +251,7 @@ func (c *Client) TriggerBatch(batch []Event) error {
 		return keyErr
 	}
 
-	payload, err := encodeTriggerBatchBody(batch, masterKey)
+	payload, err := encodeTriggerBatchBody(batch, masterKey, c.OverrideMaxMessagePayloadKB)
 	if err != nil {
 		return err
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -519,17 +519,31 @@ func TestDataSizeValidation(t *testing.T) {
 	err := client.Trigger("channel", "event", data)
 
 	assert.EqualError(t, err, "Event payload exceeded maximum size (20481 bytes is too much)")
+
+	err = client.TriggerBatch([]Event{
+		{"channel", "event", data, nil},
+	})
+	assert.EqualError(t, err, "Data of the event #0 in batch, exceeded maximum size (20481 bytes is too much)")
 }
 
 func TestDataSizeOverridenValidation(t *testing.T) {
 	client := Client{AppID: "id", Key: "key", Secret: "secret", OverrideMaxMessagePayloadKB: 80}
 	data := strings.Repeat("a", 81920)
 	err := client.Trigger("channel", "event", data)
-	assert.NotContains(t, err.Error(), "\"Event payload exceeded maximum size (81921 bytes is too much)")
+	assert.NotContains(t, err.Error(), "\"Event payload exceeded maximum size (81920 bytes is too much)")
+	err = client.TriggerBatch([]Event{
+		{"channel", "event", data, nil},
+	})
+	assert.NotContains(t, err.Error(), "Data of the event #0 in batch, exceeded maximum size (81920 bytes is too much)")
 
 	data = strings.Repeat("a", 81921)
 	err = client.Trigger("channel", "event", data)
 	assert.EqualError(t, err, "Event payload exceeded maximum size (81921 bytes is too much)")
+
+	err = client.TriggerBatch([]Event{
+		{"channel", "event", data, nil},
+	})
+	assert.EqualError(t, err, "Data of the event #0 in batch, exceeded maximum size (81921 bytes is too much)")
 }
 
 func TestInitialisationFromURL(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -521,6 +521,17 @@ func TestDataSizeValidation(t *testing.T) {
 	assert.EqualError(t, err, "Event payload exceeded maximum size (20481 bytes is too much)")
 }
 
+func TestDataSizeOverridenValidation(t *testing.T) {
+	client := Client{AppID: "id", Key: "key", Secret: "secret", OverrideMaxMessagePayloadKB: 80}
+	data := strings.Repeat("a", 81920)
+	err := client.Trigger("channel", "event", data)
+	assert.NotContains(t, err.Error(), "\"Event payload exceeded maximum size (81921 bytes is too much)")
+
+	data = strings.Repeat("a", 81921)
+	err = client.Trigger("channel", "event", data)
+	assert.EqualError(t, err, "Event payload exceeded maximum size (81921 bytes is too much)")
+}
+
 func TestInitialisationFromURL(t *testing.T) {
 	url := "http://feaf18a411d3cb9216ee:fec81108d90e1898e17a@api.pusherapp.com/apps/104060"
 	client, _ := ClientFromURL(url)


### PR DESCRIPTION
We sometimes allow more than 20KB