### PR TITLE
Accept and return concrete objects for authenticating channels

### DIFF
--- a/channel_authentication_test.go
+++ b/channel_authentication_test.go
@@ -15,33 +15,56 @@ func setUpAuthClient() Client {
 
 func TestPrivateChannelAuthentication(t *testing.T) {
 	client := setUpAuthClient()
-	postParams := []byte("channel_name=private-foobar&socket_id=1234.1234")
-	expected := "{\"auth\":\"278d425bdf160c739803:58df8b0c36d6982b82c3ecf6b4662e34fe8c25bba48f5369f135bf843651c3a4\"}"
+
+	postParams := AuthenticationParams{
+		Channel:  "private-foobar",
+		SocketID: "1234.1234",
+	}
+
+	expected := AuthenticatedChannel{
+		Auth: "278d425bdf160c739803:58df8b0c36d6982b82c3ecf6b4662e34fe8c25bba48f5369f135bf843651c3a4",
+	}
+
 	result, err := client.AuthenticatePrivateChannel(postParams)
-	assert.Equal(t, expected, string(result))
+	assert.Equal(t, expected, *result)
 	assert.NoError(t, err)
 }
 
 func TestPrivateChannelAuthenticationWrongParams(t *testing.T) {
 	client := setUpAuthClient()
-	postParams := []byte("hello=hi&two=3")
+	postParams := AuthenticationParams{}
 	_, err := client.AuthenticatePrivateChannel(postParams)
 	assert.Error(t, err)
 }
 
 func TestPresenceChannelAuthentication(t *testing.T) {
 	client := setUpAuthClient()
-	postParams := []byte("channel_name=presence-foobar&socket_id=1234.1234")
+
+	postParams := AuthenticationParams{
+		Channel:  "presence-foobar",
+		SocketID: "1234.1234",
+	}
+
+	data := "{\"user_id\":\"10\",\"user_info\":{\"name\":\"Mr. Pusher\"}}"
+	expected := AuthenticatedChannel{
+		Auth: "278d425bdf160c739803:48dac51d2d7569e1e9c0f48c227d4b26f238fa68e5c0bb04222c966909c4f7c4",
+		Data: &data,
+	}
+
 	presenceData := MemberData{UserID: "10", UserInfo: map[string]string{"name": "Mr. Pusher"}}
-	expected := "{\"auth\":\"278d425bdf160c739803:48dac51d2d7569e1e9c0f48c227d4b26f238fa68e5c0bb04222c966909c4f7c4\",\"channel_data\":\"{\\\"user_id\\\":\\\"10\\\",\\\"user_info\\\":{\\\"name\\\":\\\"Mr. Pusher\\\"}}\"}"
 	result, err := client.AuthenticatePresenceChannel(postParams, presenceData)
-	assert.Equal(t, expected, string(result))
+	assert.Equal(t, expected.Auth, result.Auth)
+	assert.Equal(t, *expected.Data, *result.Data)
 	assert.NoError(t, err)
 }
 
 func TestAuthSocketIDValidation(t *testing.T) {
 	client := setUpAuthClient()
-	postParams := []byte("channel_name=private-foobar&socket_id=12341234")
+	postParams := AuthenticationParams{
+		Channel:  "private-foobar",
+		SocketID: "12341234",
+	}
+
 	result, err := client.AuthenticatePrivateChannel(postParams)
 	assert.Nil(t, result)
 	assert.Error(t, err)

--- a/client_test.go
+++ b/client_test.go
@@ -367,7 +367,10 @@ func TestAuthenticateInvalidMasterKey(t *testing.T) {
 	defer server.Close()
 	u, _ := url.Parse(server.URL)
 
-	params := []byte("channel_name=private-encrypted-test_channel&socket_id=12345.12345")
+	params := AuthenticationParams{
+		Channel:  "private-encrypted-test_channel",
+		SocketID: "12345.12345",
+	}
 
 	// too short (deprecated)
 	client := Client{

--- a/crypto.go
+++ b/crypto.go
@@ -40,13 +40,15 @@ func checkSignature(result, secret string, body []byte) bool {
 	return hmac.Equal(expected, resultBytes)
 }
 
-func createAuthMap(key, secret, stringToSign string, sharedSecret string) map[string]string {
-	authSignature := hmacSignature(stringToSign, secret)
-	authString := strings.Join([]string{key, authSignature}, ":")
+func (a *AuthenticatedChannel) createAuthSignature(key, secret, stringToSign string, sharedSecret string) {
+	a.Auth = strings.Join([]string{
+		key,
+		hmacSignature(stringToSign, secret),
+	}, ":")
+
 	if sharedSecret != "" {
-		return map[string]string{"auth": authString, "shared_secret": sharedSecret}
+		a.SharedSecret = &sharedSecret
 	}
-	return map[string]string{"auth": authString}
 }
 
 func md5Signature(body []byte) string {

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -41,27 +41,33 @@ func TestCheckInvalidSignature(t *testing.T) {
 }
 
 func TestCreateAuthMapNoE2E(t *testing.T) {
-	signature := "64e3f44166575febbc5de88c9476325ea7d4b3684752158d9fdb31fce34b980d"
+	ac := &AuthenticatedChannel{}
+	expected := &AuthenticatedChannel{
+		Auth: "64e3f44166575febbc5de88c9476325ea7d4b3684752158d9fdb31fce34b980d",
+	}
+
 	key := "key"
 	secret := "supersecret"
 	stringToSign := "Hello!"
 	sharedSecret := ""
-	authMap := createAuthMap(key, secret, stringToSign, sharedSecret)
+	ac.createAuthSignature(key, secret, stringToSign, sharedSecret)
 	// The [4:] here removes the prefix of key: from the string.
-	assert.Equal(t, authMap["auth"][4:], signature)
-	assert.Equal(t, authMap["shared_secret"], "")
+	assert.Equal(t, ac.Auth[4:], expected.Auth)
+	assert.Equal(t, ac.SharedSecret, expected.SharedSecret)
 }
 
 func TestCreateAuthMapE2E(t *testing.T) {
+	ac := &AuthenticatedChannel{}
+
 	signature := "64e3f44166575febbc5de88c9476325ea7d4b3684752158d9fdb31fce34b980d"
 	key := "key"
 	secret := "supersecret"
 	stringToSign := "Hello!"
 	sharedSecret := "This is a string that is 32 chars"
-	authMap := createAuthMap(key, secret, stringToSign, sharedSecret)
+	ac.createAuthSignature(key, secret, stringToSign, sharedSecret)
 	// The [4:] here removes the prefix of key: from the string.
-	assert.Equal(t, authMap["auth"][4:], signature)
-	assert.Equal(t, authMap["shared_secret"], sharedSecret)
+	assert.Equal(t, ac.Auth[4:], signature)
+	assert.Equal(t, *ac.SharedSecret, sharedSecret)
 }
 
 func TestMD5Signature(t *testing.T) {


### PR DESCRIPTION
When working with the package there are many times where converting
between bytes and strings and other concrete data types is not ideal,
especially in API systems that procees the body and provide access to
mapped data structures.  Further returrning a slice of bytes back to the
caller requires the caller to parse the bytes, figure out what is
posssibly there, etc.  Of course when following the documentation and
dumping the raw result back to a reader, this process is fine.

Our use cases requiree a bit more processing and logging of the data and
so accepting and returning concrete (and explicit) types gives us the
flexibility to build as we require.