### PR TITLE
Replace $default_branch with `master`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [ master ]
+    branches: [ master, main ]
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [ $default-branch ]
+    branches: [ master ]
 
 jobs:
   test:


### PR DESCRIPTION
It turns out the $default_branch is only available in workflow _templates_.