### PR TITLE
v5.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+5.0.0 / 2021-02-19
+==================
+* Breaking change: `TriggerBatch now returns `(*TriggerBatchChannelsList, error)` instead of `error`
+* Breaking change: `Channels` takes `ChannelsParams` as a parameter instead of `map[string]string`
+* Breaking change: `Channel` takes `ChannelParams` as a parameter instead of `map[string]string`
+* Breaking change: switches to go modules using option 1. described in https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher - this will cause problems for legacy package managers like `dep`
+* Added `TriggerWithParams` and `TriggerMultiWithParams` - they provide support for requesting channel attributes by specifying an `Info` field
+* Added a `Info` field to the `Event` type passed to `TriggerBatch`
+* Deprecated `TriggerExclusive` and `TriggerMultiExclusive` (use `TriggerWithParams` and `TriggerMultiWithParams` instead)
+
 4.0.4 / 2020-09-02
 ==================
 * Allow message size to be overridden for dedicate cluster customers (PR [#63](https://github.com/pusher/pusher-http-go/pull/71))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 5.0.0 / 2021-02-19
 ==================
-* Breaking change: `TriggerBatch now returns `(*TriggerBatchChannelsList, error)` instead of `error`
+* Breaking change: `TriggerBatch` now returns `(*TriggerBatchChannelsList, error)` instead of `error`
 * Breaking change: `Channels` takes `ChannelsParams` as a parameter instead of `map[string]string`
 * Breaking change: `Channel` takes `ChannelParams` as a parameter instead of `map[string]string`
 * Breaking change: switches to go modules using option 1. described in https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher - this will cause problems for legacy package managers like `dep`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Register for free at <https://pusher.com/channels> and use the application crede
 ## Installation
 
 ```sh
-$ go get github.com/pusher/pusher-http-go
+$ go get github.com/pusher/pusher-http-go/v5
 ```
 
 ## Getting Started
@@ -41,7 +41,7 @@ $ go get github.com/pusher/pusher-http-go
 package main
 
 import (
-  "github.com/pusher/pusher-http-go"
+  "github.com/pusher/pusher-http-go/v5"
 )
 
 func main(){
@@ -187,7 +187,7 @@ import (
     "appengine"
     "appengine/urlfetch"
     "fmt"
-    "github.com/pusher/pusher-http-go"
+    "github.com/pusher/pusher-http-go/v5"
     "net/http"
 )
 

--- a/client.go
+++ b/client.go
@@ -17,7 +17,7 @@ var pusherPathRegex = regexp.MustCompile("^/apps/([0-9]+)$")
 var maxTriggerableChannels = 100
 
 const (
-	libraryVersion = "4.0.4"
+	libraryVersion = "5.0.0"
 	libraryName    = "pusher-http-go"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pusher/pusher-http-go
+module github.com/pusher/pusher-http-go/v5
 
 go 1.14
 


### PR DESCRIPTION
Note that while we already have a go.mod and go.sum files, this
package was not fully compatible with go modules because the
pacakge name had not been updated to
github.com/pusher/pusher-http-go/v4. This commit completes this
step.

We are taking the approach described in option 1. of
https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher,
and leaving major versions on the master branch.

Note that this will cause problems for legacy package managers
like `dep`.