### PR TITLE
fix: correct Go formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ This library supports end to end encryption of your private channels. This means
 
    ```go
    pusherClient := pusher.Client{
-       AppID:                    "APP_ID",
-       Key:                      "APP_KEY",
-       Secret:                   "APP_SECRET",
-       Cluster:                  "APP_CLUSTER",
-       EncryptionMasterKeyBase64 "<output from command above>",
+       AppID:                     "APP_ID",
+       Key:                       "APP_KEY",
+       Secret:                    "APP_SECRET",
+       Cluster:                   "APP_CLUSTER",
+       EncryptionMasterKeyBase64: "<output from command above>",
    }
    ```
 4. Channels where you wish to use end to end encryption should be prefixed with `private-encrypted-`.


### PR DESCRIPTION
Signed-off-by: Conor Evans <coevans@tcd.ie>

## What does this PR do?

Fixes the formatting of the Go code in the README

Before:

<img width="1020" alt="Screenshot 2022-12-15 at 10 01 58 PM" src="https://user-images.githubusercontent.com/43791257/207976475-faf81171-5f64-41f8-888f-39cfb3112c44.png">

After:

<img width="1035" alt="Screenshot 2022-12-15 at 10 02 12 PM" src="https://user-images.githubusercontent.com/43791257/207976476-5a8c27ae-f512-48ec-b781-2852fd1f35a5.png">

